### PR TITLE
Add lasteventid to context

### DIFF
--- a/src/client/use-sse.ts
+++ b/src/client/use-sse.ts
@@ -138,7 +138,9 @@ export function useSSE<T = any>({ url, eventName = 'message', reconnect = false 
           const interval = typeof reconnect === 'object' && reconnect.interval ? reconnect.interval : 1000;
           reconnectAttempts.current += 1;
           reconnectTimeout.current = window.setTimeout(() => {
-            destructor();
+            sseManager.removeEventListener(url, eventName, handleMessage);
+            source.removeEventListener('open', handleOpen);
+            source.removeEventListener('error', handleError);
             connect();
           }, interval);
         } else {

--- a/src/server/sse-server.test.ts
+++ b/src/server/sse-server.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 import { createSSEHandler } from './sse-server';
 
@@ -13,6 +13,7 @@ describe('createSSEHandler', () => {
     };
 
     mockRequest = {
+      headers: new Headers(),
       signal: mockSignal,
     } as unknown as NextRequest;
 

--- a/src/server/sse-server.ts
+++ b/src/server/sse-server.ts
@@ -27,6 +27,13 @@ type SSECallback = (
    * close();
    */
   close: () => void,
+  /**
+   * An object containing the last event ID received by the client. Not null if the client has been reconnected.
+   * @property lastEventId - The last event ID from the client.
+   * @example
+   * { lastEventId: '12345' }
+   */
+  context: {lastEventId: string | null}
 ) => void | Promise<void> | (() => void);
 
 /**
@@ -35,6 +42,7 @@ type SSECallback = (
  * @param callback - A function that handles the SSE connection. It takes two arguments: {@link SSECallback}
  *   - `send`: A function to send data to the client. See {@link SendFunction}.
  *   - `close`: A function to close the SSE connection.
+ *   - `context`: An object containing the last event ID received by the client. Not null if the client has been reconnected.
  *   The callback can return a cleanup function that will be called when the connection is closed.
  *
  * @returns A function that handles the SSE request. This function takes a `NextRequest` object as an argument.
@@ -78,7 +86,7 @@ export function createSSEHandler(callback: SSECallback) {
           }
         }
 
-        const result = callback(send, close);
+        const result = callback(send, close, {lastEventId: request.headers.get('Last-Event-ID')});
         if (typeof result === 'function') {
           cleanup = result;
         }


### PR DESCRIPTION
This pull request includes several updates to the server-sent events (SSE) functionality in both client and server code. The changes improve the handling of SSE connections, particularly around reconnection logic and context management.

### Improvements to SSE reconnection logic:

* [`src/client/use-sse.ts`](diffhunk://#diff-059a6c22858b39e26e93b1e34c949a9c4e0bd36106c014db1dae4b2a60b3995dL141-R143): Updated the `useSSE` function to properly remove event listeners (`sseManager.removeEventListener`, `source.removeEventListener`) before attempting to reconnect.

### Enhancements to SSE context management:

* [`src/server/sse-server.ts`](diffhunk://#diff-fa708660b9c7234bcebe2b24466ffd7d85c5bc90d0576b08cce84d9b960e4141R30-R36): Added a `context` object to the `SSECallback` type, which includes the `lastEventId` received by the client. This helps in managing reconnections more effectively. [[1]](diffhunk://#diff-fa708660b9c7234bcebe2b24466ffd7d85c5bc90d0576b08cce84d9b960e4141R30-R36) [[2]](diffhunk://#diff-fa708660b9c7234bcebe2b24466ffd7d85c5bc90d0576b08cce84d9b960e4141R45)
* [`src/server/sse-server.ts`](diffhunk://#diff-fa708660b9c7234bcebe2b24466ffd7d85c5bc90d0576b08cce84d9b960e4141L81-R89): Modified the `createSSEHandler` function to pass the `lastEventId` from the request headers to the `SSECallback` context.