### PR TITLE
Refactor useSSE: Add cleanup function for closing SSE connection

### DIFF
--- a/src/client/use-sse.ts
+++ b/src/client/use-sse.ts
@@ -101,14 +101,15 @@ export function useSSE<T = any>({ url, eventName = 'message', reconnect = false 
   const [connectionState, setConnectionState] = useState<'connecting' | 'open' | 'closed'>('connecting');
   const reconnectAttempts = useRef(0);
   const reconnectTimeout = useRef<number | null>(null);
+  const cleanupRef = useRef<() => void>(() => {});
 
   const close = useCallback(() => {
     if (reconnectTimeout.current) {
       clearTimeout(reconnectTimeout.current);
     }
-    sseManager.releaseConnection(url);
+    cleanupRef.current();
     setConnectionState('closed');
-  }, [url]);
+  }, [cleanupRef.current]);
 
   useEffect(() => {
     const connect = () => {
@@ -167,6 +168,7 @@ export function useSSE<T = any>({ url, eventName = 'message', reconnect = false 
     };
 
     const cleanup = connect();
+    cleanupRef.current = cleanup;
 
     return () => {
       if (reconnectTimeout.current) {


### PR DESCRIPTION
This pull request includes changes to the `useSSE` function in the `src/client/use-sse.ts` file to improve the handling of cleanup operations when closing the SSE connection. The most important changes include the addition of a `cleanupRef` to store the cleanup function and the modification of the `close` method to use this reference.

Improvements to cleanup handling:

* [`src/client/use-sse.ts`](diffhunk://#diff-059a6c22858b39e26e93b1e34c949a9c4e0bd36106c014db1dae4b2a60b3995dR104-R112): Added a `cleanupRef` to store the cleanup function, ensuring it is called when the connection is closed.
* [`src/client/use-sse.ts`](diffhunk://#diff-059a6c22858b39e26e93b1e34c949a9c4e0bd36106c014db1dae4b2a60b3995dR104-R112): Updated the `close` method to use `cleanupRef.current` instead of directly releasing the connection, improving the cleanup process.
* [`src/client/use-sse.ts`](diffhunk://#diff-059a6c22858b39e26e93b1e34c949a9c4e0bd36106c014db1dae4b2a60b3995dR171): Assigned the cleanup function to `cleanupRef.current` in the `useEffect` hook to ensure it is properly referenced.