### PR TITLE
feat: the hook is only executed if the URL is not an empty string

### DIFF
--- a/src/client/use-sse.ts
+++ b/src/client/use-sse.ts
@@ -179,6 +179,10 @@ export function useSSE<T = any>({
     };
 
     if (url === '') {
+      if (connectionState !== 'closed') {
+        close();
+      }
+
       return;
     }
 

--- a/src/client/use-sse.ts
+++ b/src/client/use-sse.ts
@@ -178,6 +178,10 @@ export function useSSE<T = any>({
       return destructor;
     };
 
+    if (url === '') {
+      return;
+    }
+
     const cleanup = connect();
     cleanupRef.current = cleanup;
 


### PR DESCRIPTION
Hello, I've never made a pull request before, so please excuse me if I'm doing something wrong.

This change allows the hook to execute only after the URL is no longer empty.

Useful in case a value returned from useQuery or useReact is used as part of the URL.

Example:

```
  const { data, isLoading } = useQuery({
    queryKey: ["create-payment"],
    queryFn: () => createPayment(formData),
  });

  const url = data ? `/api/payments/${data.id}/events` : "";

  const { data: sseData } = useSSE({
    url,
    eventName: "SchedulePaid",
    reconnect: true,
  });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic Server-Sent Events connections when no URL is provided, ensuring any open connection is closed and avoiding unnecessary connection setup, resource use, and related errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->