### PR TITLE
fix: release connection before reconnecting to prevent refCount leak

### DIFF
--- a/__tests__/use-sse.test.ts
+++ b/__tests__/use-sse.test.ts
@@ -142,6 +142,32 @@ describe('useSSE', () => {
     jest.useRealTimers();
   });
 
+  test('releases connection before each reconnect attempt', async () => {
+    jest.useFakeTimers();
+    renderHook(() => useSSE({ url: 'https://example.com/sse', reconnect: true }));
+
+    await act(async () => {
+      const errorHandler = mockEventSource.addEventListener.mock.calls.find((call) => call[0] === 'error')[1];
+      errorHandler(new Event('error'));
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(sseManager.releaseConnection).toHaveBeenCalledWith('https://example.com/sse');
+    expect(sseManager.releaseConnection).toHaveBeenCalledTimes(1);
+
+    // second reconnect — grab the latest error handler, not the stale one
+    await act(async () => {
+      const errorCalls = mockEventSource.addEventListener.mock.calls.filter((call) => call[0] === 'error');
+      const errorHandler = errorCalls[errorCalls.length - 1][1];
+      errorHandler(new Event('error'));
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(sseManager.releaseConnection).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
   test('reconnects with default interval and maxAttempts', async () => {
     jest.useFakeTimers();
     const { result } = renderHook(() => useSSE({ url: 'https://example.com/sse', reconnect: true }));

--- a/src/client/use-sse.ts
+++ b/src/client/use-sse.ts
@@ -151,7 +151,8 @@ export function useSSE<T = any>({
             sseManager.removeEventListener(url, eventName, handleMessage);
             source.removeEventListener('open', handleOpen);
             source.removeEventListener('error', handleError);
-            connect();
+            sseManager.releaseConnection(url);
+            cleanupRef.current = connect();
           }, interval);
         } else {
           destructor();
@@ -193,7 +194,7 @@ export function useSSE<T = any>({
       if (reconnectTimeout.current) {
         clearTimeout(reconnectTimeout.current);
       }
-      cleanup();
+      cleanupRef.current();
     };
   }, [url, eventName, reconnect]);
 


### PR DESCRIPTION
## Summary

When reconnection is enabled and errors occur, each reconnect attempt calls `getConnection()` (which increments `refCount`) without first calling `releaseConnection()`. After N reconnections the count is N+1, and a single cleanup on unmount only decrements it by 1 -- the EventSource stays open forever.

The fix adds a `releaseConnection` call in the reconnect timeout, right before `connect()` is called again. This keeps `refCount` balanced at 1 throughout the reconnection cycle.

## What's happening

In `use-sse.ts`, the reconnect path inside `handleError` (line 150-154) does:

```ts
reconnectTimeout.current = window.setTimeout(() => {
  sseManager.removeEventListener(url, eventName, handleMessage);
  source.removeEventListener('open', handleOpen);
  source.removeEventListener('error', handleError);
  connect();  // calls sseManager.getConnection(url) → refCount++
}, interval);
```

But `releaseConnection` is only called inside `destructor()`, which only runs when reconnection gives up (line 157) or on unmount. The reconnect path never balances the count.

## Reproduction

1. Mount a component with `useSSE({ url: '/api/sse', reconnect: { maxAttempts: 5 } })`
2. Kill the server so 5 reconnection errors fire
3. Unmount the component
4. The EventSource stays open -- `refCount` is 5 instead of 0

## Changes

- Added `sseManager.releaseConnection(url)` before `connect()` in the reconnect timeout
- Added a test that verifies `releaseConnection` is called before each reconnect attempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection resources are now released before each automatic reconnection attempt, preventing resource leaks and ensuring clean reconnects.

* **Tests**
  * Added test coverage that simulates consecutive reconnect attempts and verifies resources are released for each reconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->