### PR TITLE
fix: stabilize useEffect and useCallback dependency arrays

### DIFF
--- a/__tests__/use-sse.test.ts
+++ b/__tests__/use-sse.test.ts
@@ -216,37 +216,45 @@ describe('useSSE', () => {
       useSSE({ url: 'https://example.com/sse', reconnect: { interval: 1000, maxAttempts: 2 } }),
     );
 
+    expect(sseManager.getConnection).toHaveBeenCalledTimes(1);
+
+    // first error → schedules reconnect attempt 1
     await act(async () => {
       const errorHandler = mockEventSource.addEventListener.mock.calls.find((call) => call[0] === 'error')[1];
       errorHandler(new Event('error'));
-
-      expect(result.current.connectionState).toBe('connecting');
-      expect(sseManager.getConnection).toHaveBeenCalledTimes(1);
     });
 
     await act(async () => {
-      const errorHandler = mockEventSource.addEventListener.mock.calls.find((call) => call[0] === 'error')[1];
-      errorHandler(new Event('error'));
-
-      // jest.advanceTimersByTime(1000);
-      expect(sseManager.getConnection).toHaveBeenCalledTimes(3);
+      jest.advanceTimersByTime(1000);
     });
 
+    expect(sseManager.getConnection).toHaveBeenCalledTimes(2);
+
+    // second error → schedules reconnect attempt 2
     await act(async () => {
       const errorHandler = mockEventSource.addEventListener.mock.calls.find((call) => call[0] === 'error')[1];
       errorHandler(new Event('error'));
-
-      expect(sseManager.getConnection).toHaveBeenCalledTimes(5);
     });
 
     await act(async () => {
-      const errorHandler = mockEventSource.addEventListener.mock.calls.find((call) => call[0] === 'error')[1];
-      errorHandler(new Event('error'));
-      expect(sseManager.getConnection).toHaveBeenCalledTimes(7);
+      jest.advanceTimersByTime(1000);
     });
 
-    jest.advanceTimersByTime(1000);
-    expect(sseManager.getConnection).toHaveBeenCalledTimes(9); // No more attempts after maxAttempts
+    expect(sseManager.getConnection).toHaveBeenCalledTimes(3);
+
+    // third error → maxAttempts (2) reached, no more reconnects
+    await act(async () => {
+      const errorHandler = mockEventSource.addEventListener.mock.calls.find((call) => call[0] === 'error')[1];
+      errorHandler(new Event('error'));
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // no additional getConnection call
+    expect(sseManager.getConnection).toHaveBeenCalledTimes(3);
+    expect(result.current.connectionState).toBe('closed');
 
     jest.useRealTimers();
   });

--- a/src/client/use-sse.ts
+++ b/src/client/use-sse.ts
@@ -119,7 +119,11 @@ export function useSSE<T = any>({
     }
     cleanupRef.current();
     setConnectionState('closed');
-  }, [cleanupRef.current]);
+  }, []);
+
+  const reconnectEnabled = !!reconnect;
+  const reconnectInterval = typeof reconnect === 'object' ? reconnect.interval : undefined;
+  const reconnectMaxAttempts = typeof reconnect === 'object' ? reconnect.maxAttempts : undefined;
 
   useEffect(() => {
     const connect = () => {
@@ -195,7 +199,7 @@ export function useSSE<T = any>({
       }
       cleanup();
     };
-  }, [url, eventName, reconnect]);
+  }, [url, eventName, withCredentials, reconnectEnabled, reconnectInterval, reconnectMaxAttempts]);
 
   return { data, error, lastEventId, close, connectionState };
 }


### PR DESCRIPTION
## Summary

Two dependency array issues in `use-sse.ts` that can cause unexpected behavior:

1. **`reconnect` object in useEffect deps causes infinite re-renders.** Passing `reconnect` as an object literal (e.g. `{ interval: 1000, maxAttempts: 5 }`) creates a new reference every render. Since React compares deps with `Object.is`, the effect re-runs on every render, which updates state, which triggers another render -- infinite loop.

2. **`cleanupRef.current` in useCallback deps can produce a stale `close` callback.** The ref's `.current` is read when the dependency array is evaluated, not when the callback runs. Since mutating a ref doesn't cause a re-render, `useCallback` can hold onto the initial no-op `() => {}` instead of the real cleanup function.

## Changes

### 1. Destructure `reconnect` into stable primitives

Before:
```ts
}, [url, eventName, reconnect]);
```

After:
```ts
const reconnectEnabled = !!reconnect;
const reconnectInterval = typeof reconnect === 'object' ? reconnect.interval : undefined;
const reconnectMaxAttempts = typeof reconnect === 'object' ? reconnect.maxAttempts : undefined;

useEffect(() => {
  // ...
}, [url, eventName, reconnectEnabled, reconnectInterval, reconnectMaxAttempts]);
```

Primitives are compared by value, so the effect stays stable across renders.

### 2. Remove `cleanupRef.current` from useCallback deps

Before:
```ts
const close = useCallback(() => {
  // ...
  cleanupRef.current();
  setConnectionState('closed');
}, [cleanupRef.current]);
```

After:
```ts
const close = useCallback(() => {
  // ...
  cleanupRef.current();
  setConnectionState('closed');
}, []);
```

The ref is read at call time inside the callback, so it's always fresh. No need to track it as a dependency.

## Reproduction

**Infinite re-renders:**
```tsx
function MyComponent() {
  // freezes the browser
  const { data } = useSSE({ url: '/api/sse', reconnect: { interval: 1000, maxAttempts: 5 } });
  return <div>{JSON.stringify(data)}</div>;
}
```

**Stale close:** Call `close()` from an event handler that fires before any state-driven re-render after the effect runs. The EventSource won't actually close because `close` is calling the initial no-op.

## Note on the test change

The `does not reconnect when maxAttempts is reached` test was updated because its expected `getConnection` call counts (3, 5, 7, 9) were a side-effect of the bug itself -- the effect was re-running on every render due to the unstable `reconnect` reference, which inflated the counts. With `maxAttempts: 2`, the correct count is 3 (1 initial + 2 reconnects), not 9. The test now follows the actual reconnection flow: fire error, advance the timer, check the count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened tests for reconnection backoff, ensuring retries follow expected timing and stop at the configured maximum.

* **Refactor**
  * Improved dependency handling for the server-sent events hook to ensure reconnection behavior updates correctly when related options change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->