### PR TITLE
fix: prevent native EventSource listener stacking on reconnect

### DIFF
--- a/src/client/sse-manager.test.ts
+++ b/src/client/sse-manager.test.ts
@@ -45,4 +45,44 @@ describe('SSEManager', () => {
       expect(sseManager['connections'].has(url)).toBe(false);
     });
   });
+
+  describe('listener stacking on reconnect (#32)', () => {
+    test('after a reconnect cycle, a message is delivered only once', () => {
+      const url = 'https://example.com/reconnect';
+
+      // Track native listeners like a real EventSource would
+      const nativeListeners = new Map<string, Set<Function>>();
+      mockEventSource.addEventListener.mockImplementation((name: string, fn: Function) => {
+        if (!nativeListeners.has(name)) nativeListeners.set(name, new Set());
+        nativeListeners.get(name)!.add(fn);
+      });
+      mockEventSource.removeEventListener.mockImplementation((name: string, fn: Function) => {
+        nativeListeners.get(name)?.delete(fn);
+      });
+
+      const dispatch = (eventName: string, data: any) => {
+        nativeListeners.get(eventName)?.forEach((fn) => fn(data));
+      };
+
+      // 1. Initial connection — this is what useSSE does on mount
+      sseManager.getConnection(url);
+      const handler1 = jest.fn();
+      sseManager.addEventListener(url, 'message', handler1);
+
+      // 2. Reconnect tears down the listener but NOT the connection
+      //    (use-sse.ts:154-158 — removeEventListener without releaseConnection)
+      sseManager.removeEventListener(url, 'message', handler1);
+
+      // 3. Reconnect re-establishes — getConnection + addEventListener
+      sseManager.getConnection(url);
+      const handler2 = jest.fn();
+      sseManager.addEventListener(url, 'message', handler2);
+
+      // 4. A message arrives from the server
+      dispatch('message', { data: '{"count":1}' });
+
+      // handler2 should be called exactly once, not twice
+      expect(handler2).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/client/sse-manager.ts
+++ b/src/client/sse-manager.ts
@@ -1,7 +1,12 @@
 type Listener = (event: MessageEvent) => void;
 
+type ListenerEntry = {
+  forwarder: EventListener;
+  userListeners: Set<Listener>;
+};
+
 class SSEManager {
-  private connections: Map<string, { source: EventSource; refCount: number; listeners: Map<string, Set<Listener>> }> =
+  private connections: Map<string, { source: EventSource; refCount: number; listeners: Map<string, ListenerEntry> }> =
     new Map();
 
   getConnection(url: string, init?: EventSourceInit): EventSource {
@@ -29,24 +34,28 @@ class SSEManager {
   addEventListener(url: string, eventName: string, listener: Listener) {
     const connection = this.connections.get(url);
     if (connection) {
-      if (!connection.listeners.has(eventName)) {
-        connection.listeners.set(eventName, new Set());
-        connection.source.addEventListener(eventName, (event) => {
-          const listeners = connection.listeners.get(eventName);
-          listeners?.forEach((listener) => listener(event));
-        });
+      let entry = connection.listeners.get(eventName);
+      if (!entry) {
+        const forwarder: EventListener = (event) => {
+          const entry = connection.listeners.get(eventName);
+          entry?.userListeners.forEach((listener) => listener(event as MessageEvent));
+        };
+        entry = { forwarder, userListeners: new Set() };
+        connection.listeners.set(eventName, entry);
+        connection.source.addEventListener(eventName, forwarder);
       }
-      connection.listeners.get(eventName)!.add(listener);
+      entry.userListeners.add(listener);
     }
   }
 
   removeEventListener(url: string, eventName: string, listener: Listener) {
     const connection = this.connections.get(url);
     if (connection) {
-      const listeners = connection.listeners.get(eventName);
-      if (listeners) {
-        listeners.delete(listener);
-        if (listeners.size === 0) {
+      const entry = connection.listeners.get(eventName);
+      if (entry) {
+        entry.userListeners.delete(listener);
+        if (entry.userListeners.size === 0) {
+          connection.source.removeEventListener(eventName, entry.forwarder);
           connection.listeners.delete(eventName);
         }
       }


### PR DESCRIPTION
## Summary

- Fixes a bug where native EventSource handlers stack up when `removeEventListener` deletes the Map key but the connection survives (e.g. reconnect path calls `removeEventListener` without `releaseConnection`, then `getConnection` + `addEventListener` again)
- Stores the native forwarder reference alongside the user listener Set so it can be passed to `source.removeEventListener` when the Set empties
- Adds a failing test that reproduces the issue — checkout `b5f5193` to see it fail against the original code

Fixes #32

## Test plan

- [ ] `npx jest src/client/sse-manager.test.ts` — new test passes with fix, fails without
- [ ] Full test suite (`npx jest`) — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate event handler invocation that could occur during SSE reconnections.

* **Tests**
  * Added test coverage verifying listener behavior when connections are re-established.

* **Refactor**
  * Internal event-dispatching logic reworked to centralize native handlers and ensure single invocation per listener.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->